### PR TITLE
fix: error when numba compiles error message, namespace pollution

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -350,3 +350,12 @@ Adds a printed warning when percolation fails a sanity check, where the total
 water after percolating is greater than the initially available water.
 
 The warning includes the timestep when this occurs.
+
+###
+fix: error when numba compiles error message, namespace pollution
+
+Adds and refactors tests for albedo parametrisation.
+
+Fixes:
+    - numba throwing an Exception when raising a ValueError with a message.
+    - namespace pollution when importing from constants.

--- a/cosipy/modules/albedo.py
+++ b/cosipy/modules/albedo.py
@@ -1,15 +1,19 @@
 import numpy as np
-from constants import albedo_method, albedo_fresh_snow, albedo_firn, albedo_ice, \
-                      albedo_mod_snow_aging, albedo_mod_snow_depth, snow_ice_threshold
+import constants
 
 def updateAlbedo(GRID):
     """ This methods updates the albedo """
     albedo_allowed = ['Oerlemans98']
-    if albedo_method == 'Oerlemans98':
+    if constants.albedo_method == 'Oerlemans98':
         alphaMod = method_Oerlemans(GRID)
 
     else:
-        raise ValueError("Albedo method = \"{:s}\" is not allowed, must be one of {:s}".format(albedo_method, ", ".join(albedo_allowed)))
+        error_message = (
+            f'Albedo method = "{constants.albedo_method}"',
+            f'is not allowed, must be one of',
+            f'{", ".join(albedo_allowed)}'
+        )
+        raise ValueError(" ".join(error_message))
 
     return alphaMod
 
@@ -25,7 +29,7 @@ def method_Oerlemans(GRID):
 
     # If fresh snow disappears faster than the snow ageing scale then set the hours_since_snowfall
     # to the old values of the underlying snowpack
-    if (hours_since_snowfall < (albedo_mod_snow_aging * 24)) & (
+    if (hours_since_snowfall < (constants.albedo_mod_snow_aging * 24)) & (
         fresh_snow_height <= 0.0
         ):
         GRID.set_fresh_snow_props_to_old_props()
@@ -35,18 +39,18 @@ def method_Oerlemans(GRID):
         hours_since_snowfall = (fresh_snow_timestamp)/3600.0
 
     # Check if snow or ice
-    if (GRID.get_node_density(0) <= snow_ice_threshold):
+    if (GRID.get_node_density(0) <= constants.snow_ice_threshold):
         
         # Get current snowheight from layer height
         h = GRID.get_total_snowheight() #np.sum(GRID.get_height()[0:idx])
 
         # Surface albedo according to Oerlemans & Knap 1998, JGR)
-        alphaSnow = albedo_firn + (albedo_fresh_snow - albedo_firn) *  np.exp((-hours_since_snowfall) / (albedo_mod_snow_aging * 24.0))
-        alphaMod = alphaSnow + (albedo_ice - alphaSnow) *  np.exp((-1.0*h) / (albedo_mod_snow_depth / 100.0))
+        alphaSnow = constants.albedo_firn + (constants.albedo_fresh_snow - constants.albedo_firn) *  np.exp((-hours_since_snowfall) / (constants.albedo_mod_snow_aging * 24.0))
+        alphaMod = alphaSnow + (constants.albedo_ice - alphaSnow) *  np.exp((-1.0*h) / (constants.albedo_mod_snow_depth / 100.0))
 
     else:
         # If no snow cover than set albedo to ice albedo
-        alphaMod = albedo_ice
+        alphaMod = constants.albedo_ice
 
     return alphaMod
 

--- a/cosipy/tests/test_parameterisation_albedo.py
+++ b/cosipy/tests/test_parameterisation_albedo.py
@@ -1,23 +1,86 @@
 import numpy as np
 
+import pytest
 import constants
 from COSIPY import start_logging
-from cosipy.modules.albedo import updateAlbedo
+import cosipy.modules.albedo as module_albedo
 
 
-class TestParamAlbedo:
-    """Tests methods for parametrising albedo."""
+class TestParamAlbedoUpdate:
+    """Tests get/set methods for albedo properties."""
 
-    def test_updateAlbedo(self, conftest_mock_grid, conftest_mock_grid_ice):
-        GRID = conftest_mock_grid
-        GRID_ice = conftest_mock_grid_ice
+    def test_updateAlbedo(self, conftest_mock_grid):
+        grid = conftest_mock_grid
 
-        albedo = updateAlbedo(GRID)
+        albedo = module_albedo.updateAlbedo(grid)
         assert isinstance(albedo, float)
         assert (
             albedo >= constants.albedo_firn
             and albedo <= constants.albedo_fresh_snow
         )
 
-        albedo = updateAlbedo(GRID_ice)
-        assert np.isclose(albedo, constants.albedo_ice)
+    def test_updateAlbedo_ice(
+        self, conftest_mock_grid_ice, conftest_boilerplate
+    ):
+        grid_ice = conftest_mock_grid_ice
+        albedo = module_albedo.updateAlbedo(grid_ice)
+        assert conftest_boilerplate.check_output(
+            albedo, float, constants.albedo_ice
+        )
+
+
+class TestParamAlbedoSelection:
+    """Tests user selection of parametrisation method."""
+
+    @pytest.mark.parametrize("arg_method", ["Oerlemans98"])
+    def test_updateAlbedo_method(
+        self, monkeypatch, conftest_mock_grid, conftest_boilerplate, arg_method
+    ):
+        """Set method from constants.py when calculating albedo."""
+
+        grid = conftest_mock_grid
+
+        conftest_boilerplate.patch_variable(
+            monkeypatch, module_albedo.constants, {"albedo_method": arg_method}
+        )
+        assert constants.albedo_method == arg_method
+        albedo = module_albedo.updateAlbedo(grid)
+        assert isinstance(albedo, float)
+
+    @pytest.mark.parametrize("arg_method", ["Wrong Method", "", None])
+    def test_updateAlbedo_method_error(
+        self, monkeypatch, conftest_mock_grid, conftest_boilerplate, arg_method
+    ):
+        grid = conftest_mock_grid
+        valid_methods = ["Oerlemans98"]
+
+        conftest_boilerplate.patch_variable(
+            monkeypatch, module_albedo.constants, {"albedo_method": arg_method}
+        )
+        assert constants.albedo_method == arg_method
+        error_message = (
+            f'Albedo method = "{constants.albedo_method}"',
+            f"is not allowed, must be one of",
+            f'{", ".join(valid_methods)}',
+        )
+
+        with pytest.raises(ValueError, match=" ".join(error_message)):
+            module_albedo.updateAlbedo(grid)
+
+
+class TestParamAlbedoMethods:
+    """Tests methods for parametrising albedo."""
+
+    def test_method_Oerlemans(self, conftest_mock_grid):
+        """Get surface albedo without accounting for snow depth."""
+
+        grid = conftest_mock_grid
+        albedo_limit = constants.albedo_firn + (
+            constants.albedo_fresh_snow - constants.albedo_firn
+        ) * np.exp((0) / (constants.albedo_mod_snow_aging * 24.0))
+
+        compare_albedo = module_albedo.method_Oerlemans(grid)
+
+        assert isinstance(compare_albedo, float)
+        assert 0.0 <= compare_albedo <= 1.0
+        assert compare_albedo <= albedo_limit


### PR DESCRIPTION
Adds and refactors tests for albedo parametrisation.

Fixes:
    - numba throwing an Exception when raising a ValueError with a message.
    - namespace pollution when importing from constants.